### PR TITLE
Enable the use of custom TLS certificates

### DIFF
--- a/source/sashimi.h
+++ b/source/sashimi.h
@@ -43,7 +43,7 @@ void sashimi_connect_callback (sashimiConnection*, void (*) (gpointer), gpointer
 void sashimi_read_callback (sashimiConnection* conn, void (*) (const gchar*, gpointer), gpointer);
 void sashimi_disconnect_callback (sashimiConnection*, void (*) (gpointer), gpointer);
 
-gboolean sashimi_connect (sashimiConnection*, const gchar*, guint, gboolean);
+gboolean sashimi_connect (sashimiConnection*, const gchar*, guint, gboolean, gchar*);
 gboolean sashimi_disconnect (sashimiConnection*);
 
 gboolean sashimi_send (sashimiConnection*, const gchar*);

--- a/source/server.c
+++ b/source/server.c
@@ -452,7 +452,7 @@ maki_server_internal_connect (makiServer* serv)
 	gboolean ret;
 	makiNetwork* net = maki_instance_network(serv->instance);
 	gboolean ssl;
-	gchar* address;
+	gchar* address, *ssl_cert;
 	gint port;
 
 	maki_network_update(net);
@@ -466,8 +466,9 @@ maki_server_internal_connect (makiServer* serv)
 	address = g_key_file_get_string(serv->key_file, "server", "address", NULL);
 	port = g_key_file_get_integer(serv->key_file, "server", "port", NULL);
 	ssl = g_key_file_get_boolean(serv->key_file, "server", "ssl", NULL);
+	ssl_cert = g_key_file_get_string(serv->key_file, "server", "ssl_cert", NULL);
 
-	ret = sashimi_connect(serv->connection, address, port, ssl);
+	ret = sashimi_connect(serv->connection, address, port, ssl, ssl_cert);
 
 	g_free(address);
 


### PR DESCRIPTION
This is done by initializing a newly created TLS database with
just the supplied certificate and replacing the system wide TLS
database of the connection with the newly created one.

This requires a new server property called "ssl_cert" which is
ignored when empty (empty string).
